### PR TITLE
Add dynamic porting for Express

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node server.js",
+    "heroku-postbuild": " NPM_CONFIG_PRODUCTION=false npm install --prefix frontend && npm run build --prefix frontend"
   },
   "author": "",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,9 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
 
+// get port information
+const PORT = process.env.PORT || 5000;
+
 // get routes
 const userRoutes = require('./routes/user');
 
@@ -9,6 +12,12 @@ const userRoutes = require('./routes/user');
 const app = express();
 app.use(cors());
 app.use(bodyParser.json());
+
+// set the port
+app.set('port', PORT);
+
+// link api routes
+app.use('/user', userRoutes);
 
 app.use((req, res, next) =>
 {
@@ -23,8 +32,9 @@ app.use((req, res, next) =>
     );
     next();
 });
-        
-app.listen(5000); // start Node + Express server on port 5000
-
-// set the user api routes
-app.use('/user', userRoutes);
+   
+// Start express
+app.listen(PORT, () => 
+{
+    console.log('Server listening on port ' + PORT);
+});

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
+const path = require('path');
 
 // get port information
 const PORT = process.env.PORT || 5000;
@@ -38,3 +39,13 @@ app.listen(PORT, () =>
 {
     console.log('Server listening on port ' + PORT);
 });
+
+if (process.env.NODE_ENV === 'production')
+{
+    app.use(express.static('frontend/build'));
+
+    app.get('*', (req, res) =>
+    {
+        res.sendFile(path.resulve(__dirname, 'frontend', 'build', 'index.html'));
+    });
+}


### PR DESCRIPTION
## Overview
Check if the `PORT` environment variable is defined and start Express listening on that port, else on `5000`. Additionally, check if the application is being run in production and if so, build the frontend. 