### PR TITLE
Return bad request when required body information cannot be processed

### DIFF
--- a/controllers/login.js
+++ b/controllers/login.js
@@ -11,10 +11,22 @@ const login = (async (req, res, next) =>
     let ret = {};
     ret.error = '';
 
-    // process body
-    const { username, password } = req.body;
-    let _username = username.trim();
-    let _password = password.trim();
+    let _username = '';
+    let _password = '';
+
+    try 
+    {
+        // process body
+        const { username, password } = req.body;
+        _username = username.trim();
+        _password = password.trim();
+    }
+    catch (e) 
+    {
+        ret.error = 'Bad request syntax. Missing or incorrect information.'
+        res.status(400).json(ret);
+        return;
+    }
 
     const body = 
     {

--- a/controllers/register.js
+++ b/controllers/register.js
@@ -11,14 +11,30 @@ const register = (async (req, res, next) =>
     let ret = {};
     ret.error = '';
 
-    // process body 
-    const { username, password, confirmPassword, firstName, lastName, email } = req.body;
-    let _username = username.trim();
-    let _password = password.trim();
-    let _confirmPassword = confirmPassword.trim();
-    let _firstName = firstName.trim();
-    let _lastName = lastName.trim();
-    let _email = email.trim();
+    let _username = '';
+    let _password = '';
+    let _confirmPassword = '';
+    let _firstName = '';
+    let _lastName = '';
+    let _email = '';
+
+    try
+    {
+        // process body 
+        const { username, password, confirmPassword, firstName, lastName, email } = req.body;
+        _username = username.trim();
+        _password = password.trim();
+        _confirmPassword = confirmPassword.trim();
+        _firstName = firstName.trim();
+        _lastName = lastName.trim();
+        _email = email.trim();
+    }
+    catch (e) 
+    {
+        ret.error = 'Bad request syntax. Missing or incorrect information.'
+        res.status(400).json(ret);
+        return;
+    }
 
     // check if passwords match
     if (_password !== _confirmPassword)


### PR DESCRIPTION
## Overview
Previously, the endpoints would simply break when a bad request was sent. The client would see an internal server error (5oo), which could be misleading as to why the request was not working. This change checks the request body and returns a bad request (400) if the information cannot be processed as expected. 

Closes #15 