### PR TITLE
Move bearer to header

### DIFF
--- a/controllers/login.js
+++ b/controllers/login.js
@@ -64,7 +64,7 @@ const login = (async (req, res, next) =>
             id: query[0]._id.toString(),
             login: body.Login
         }
-        ret.bearer = await generateJWT(tokenBody);
+        res.set('Authorization', 'Bearer ' + await generateJWT(tokenBody));
 
         // add user information
         ret.firstName = query[0].FirstName;

--- a/controllers/register.js
+++ b/controllers/register.js
@@ -60,6 +60,8 @@ const register = (async (req, res, next) =>
         client.connect();
         const db = client.db()
 
+        let bearer = '';
+
         // check if username exists
         const duplicate = await db.collection('Users').find({Login: newUser.Login}).toArray();
         if (duplicate.length > 0)
@@ -74,8 +76,9 @@ const register = (async (req, res, next) =>
                 id: newUser._id.toString(),
                 login: newUser.Login
             }
-            ret.bearer = await generateJWT(tokenBody);
+            bearer =  await generateJWT(tokenBody);
         }
+        res.set('Authorization', 'Bearer ' + bearer);
         
         // return success
         res.status(200).json(ret);


### PR DESCRIPTION
## Overview
Move the authorization of a request to the headers. This way, it works no matter the request type (e.g. `POST` vs `GET`). 