### PR TITLE
Change local express port

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const cors = require('cors');
 const path = require('path');
 
 // get port information
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 3001;
 
 // get routes
 const userRoutes = require('./routes/user');


### PR DESCRIPTION
## Overview
Switch the local express port from `5000`->`3001`. No longer conflicts with Apple devices.

## Additional notes
This ONLY applies to local development. Port is automatically set on deployment. 