### PR TITLE
Move authorization token to response body

### DIFF
--- a/controllers/login.js
+++ b/controllers/login.js
@@ -64,7 +64,7 @@ const login = (async (req, res, next) =>
             id: query[0]._id.toString(),
             login: body.Login
         }
-        res.set('Authorization', 'Bearer ' + await generateJWT(tokenBody));
+        ret.bearer = await generateJWT(tokenBody);
 
         // add user information
         ret.firstName = query[0].FirstName;

--- a/controllers/register.js
+++ b/controllers/register.js
@@ -60,8 +60,6 @@ const register = (async (req, res, next) =>
         client.connect();
         const db = client.db()
 
-        let bearer = '';
-
         // check if username exists
         const duplicate = await db.collection('Users').find({Login: newUser.Login}).toArray();
         if (duplicate.length > 0)
@@ -76,9 +74,8 @@ const register = (async (req, res, next) =>
                 id: newUser._id.toString(),
                 login: newUser.Login
             }
-            bearer =  await generateJWT(tokenBody);
+            ret.bearer = await generateJWT(tokenBody);
         }
-        res.set('Authorization', 'Bearer ' + bearer);
         
         // return success
         res.status(200).json(ret);


### PR DESCRIPTION
## Overview
Previously, I was under the impression that the authorization token should solely reside in the headers of a request. However, that is not exactly how it works. 

When a user is making a request that requires authorization (e.g. adding a friend), the authorization token should go into the headers of that request, not the payload. The authorization token is not the purpose of the request, merely a required part, or header, for it. 

When a user is making a request that gives them authorization (e.g. logging into their account), the authorization token should be returned in the response object, NOT the header. The authorization token IS the purpose of the request, in order to gain authorization for the application and future requests. Therefore, it should be returned in the response. 

This change should reflect that idea. Future API endpoints and requests to them should be made in this way.  