### PR TITLE
Implement unfriend endpoint

### DIFF
--- a/controllers/removeFriend.js
+++ b/controllers/removeFriend.js
@@ -1,25 +1,10 @@
-const { verifyJWT } = require('../utils/auth');
-
 const removeFriend = (async (req, res, next) => 
 {
     // header: auth token
     // body: friend username
     // response: error
 
-    // initialize response object
-    let ret = {};
-    ret.error = '';
-
-
-    const token = req.get('Authorization');
-    if (token === undefined)
-    {
-        ret.error = 'Could not authenticate request.';
-        res.status(401).json(ret);
-        return;
-    }
-
-    res.status(200).json({});
+    res.status(200).json(res.locals.ret);
 });
 
 module.exports = { removeFriend };

--- a/controllers/removeFriend.js
+++ b/controllers/removeFriend.js
@@ -4,6 +4,45 @@ const removeFriend = (async (req, res, next) =>
     // body: friend username
     // response: error
 
+    // process body
+    let _friend = '';
+    try
+    {
+        const { friend } = req.body;
+        _friend = friend.trim();
+    }    
+    catch (e)
+    {
+        res.locals.ret.error = 'Bad request syntax. Missing or incorrect information.'
+        res.status(400).json(res.locals.ret);
+        return;
+    }
+
+    const requestBody = 
+    {
+        user1: res.locals.token.login,
+        user2: _friend
+    }
+
+    try
+    {
+        const client = getMongoClient();
+        client.connect();
+        const db = client.db();
+
+        const query = await db.collection('Users').find(body).toArray();
+
+        if (query.length < 1)
+        {
+            res.locals.ret.error = 'Could not find friendship.'
+            res.status(200).json(res.locals.ret);
+        }
+    }
+    catch (e) 
+    {
+
+    }
+
     res.status(200).json(res.locals.ret);
 });
 

--- a/controllers/removeFriend.js
+++ b/controllers/removeFriend.js
@@ -1,0 +1,25 @@
+const { verifyJWT } = require('../utils/auth');
+
+const removeFriend = (async (req, res, next) => 
+{
+    // header: auth token
+    // body: friend username
+    // response: error
+
+    // initialize response object
+    let ret = {};
+    ret.error = '';
+
+
+    const token = req.get('Authorization');
+    if (token === undefined)
+    {
+        ret.error = 'Could not authenticate request.';
+        res.status(401).json(ret);
+        return;
+    }
+
+    res.status(200).json({});
+});
+
+module.exports = { removeFriend };

--- a/controllers/removeFriend.js
+++ b/controllers/removeFriend.js
@@ -1,3 +1,5 @@
+const { getMongoClient } = require('../utils/database');
+
 const removeFriend = (async (req, res, next) => 
 {
     // header: auth token
@@ -30,17 +32,23 @@ const removeFriend = (async (req, res, next) =>
         client.connect();
         const db = client.db();
 
-        const query = await db.collection('Users').find(body).toArray();
+        // attempt to delete relationship
+        const del = await db.collection('Relationships').deleteOne(requestBody);
 
-        if (query.length < 1)
+        // check if deletion occured 
+        if (del.acknowledged === true && del.deletedCount === 0)
         {
             res.locals.ret.error = 'Could not find friendship.'
             res.status(200).json(res.locals.ret);
+            return;
+
         }
     }
     catch (e) 
     {
-
+        res.locals.ret.error = 'Encountered an error while removing friend.';
+        res.status(500).json(res.locals.ret);
+        return;
     }
 
     res.status(200).json(res.locals.ret);

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,31 @@
+const { verifyJWT } = require('../utils/auth');
+
+const authenticate = (async (req, res, next) =>
+{
+    res.locals.ret = {};
+    res.locals.ret.error = '';
+    
+    try
+    {
+        // check for authorization header
+        const auth = req.get('Authorization');
+        if (auth === undefined) throw new Error();
+
+        // verify bearer
+        const token = await verifyJWT(auth.split(' ')[1]);
+        if (Object.keys(token).length < 1) throw new Error();
+
+        // save token body
+        res.locals.token = token;
+    }
+    catch (e)
+    {
+        res.locals.ret.error = 'Could not authenticate request.';
+        res.status(401).json(res.locals.ret);
+        return;
+    }
+
+    next();
+});
+
+module.exports = { authenticate };

--- a/routes/friends.js
+++ b/routes/friends.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+const { removeFriend } = require('../controllers/removeFriend');
+
+router.post('/remove', removeFriend);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const PORT = process.env.PORT || 3001;
 
 // get routes
 const userRoutes = require('./routes/user');
+const friendRoutes = require('./routes/friends');
 
 // initialize express
 const app = express();
@@ -19,6 +20,7 @@ app.set('port', PORT);
 
 // link api routes
 app.use('/user', userRoutes);
+app.use('/friends', friendRoutes);
 
 app.use((req, res, next) =>
 {

--- a/server.js
+++ b/server.js
@@ -10,6 +10,9 @@ const PORT = process.env.PORT || 3001;
 const userRoutes = require('./routes/user');
 const friendRoutes = require('./routes/friends');
 
+// get middleware
+const { authenticate } = require('./middleware/auth');
+
 // initialize express
 const app = express();
 app.use(cors());
@@ -20,6 +23,8 @@ app.set('port', PORT);
 
 // link api routes
 app.use('/user', userRoutes);
+
+app.use('/friends', authenticate);
 app.use('/friends', friendRoutes);
 
 app.use((req, res, next) =>


### PR DESCRIPTION
## Overview
Write the unfriend user endpoint. Adds middleware to authenticate the request. The server first checks the bearer token located in the request headers and if it is able to authenticate the request, moves on to delete the relationship between the user that is authenticated and the friend's username provided in the request body. The endpoint returns an error string which is empty upon success. 

## Documentation
### Example
#### Header
```json
"Authorization": "Bearer <bearer-token>"
```
#### Body
```json
{
    "friend": "kinneyan"
}
```
#### Response
```json
{
    "error": ""
}
```