### PR TITLE
Set expire time on signed JWT tokens

### DIFF
--- a/utils/auth.js
+++ b/utils/auth.js
@@ -15,6 +15,7 @@ const generateJWT = (async (body) =>
     return await new jose.SignJWT(body)
         .setProtectedHeader({alg: 'HS256'})
         .setIssuedAt()
+        .setExpirationTime('1h')
         .sign(secret);
 });
 


### PR DESCRIPTION
## Overview
Previously, generated JWT bearer tokens would be valid until the secret was changed. This change sets generated keys to expire in one hour from generation, implementing extra security so keys cannot be stored forever. 