### PR TITLE
Move middlware to routes

### DIFF
--- a/routes/friends.js
+++ b/routes/friends.js
@@ -3,6 +3,9 @@ const router = express.Router();
 
 const { removeFriend } = require('../controllers/removeFriend');
 
+// get middleware
+const { authenticate } = require('../middleware/auth');
+router.post('/remove', authenticate);
 router.post('/remove', removeFriend);
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -10,9 +10,6 @@ const PORT = process.env.PORT || 3001;
 const userRoutes = require('./routes/user');
 const friendRoutes = require('./routes/friends');
 
-// get middleware
-const { authenticate } = require('./middleware/auth');
-
 // initialize express
 const app = express();
 app.use(cors());
@@ -24,7 +21,6 @@ app.set('port', PORT);
 // link api routes
 app.use('/user', userRoutes);
 
-app.use('/friends', authenticate);
 app.use('/friends', friendRoutes);
 
 app.use((req, res, next) =>


### PR DESCRIPTION
## Overview
Middleware should be invoked in each routes file. This is so that we can control which endpoints use the middleware, and which do not. If called in `server.js`, all endpoints have to use it. We do not want this. 