### PR TITLE
Change response status codes of API responses

### DIFF
--- a/controllers/addFriend.js
+++ b/controllers/addFriend.js
@@ -31,7 +31,7 @@ const addFriend = (async (req, res, next) =>
         if (users.length < 1)
         {
             res.locals.ret.error = _friend + ' is not a user.';
-            res.status(200).json(res.locals.ret);
+            res.status(409).json(res.locals.ret);
             return;
         }
 
@@ -66,7 +66,7 @@ const addFriend = (async (req, res, next) =>
             if (relationships[0].RelationshipType == 'friends')
             {
                 res.locals.ret.error = 'Already friends with ' + _friend + '.';
-                res.status(200).json(res.locals.ret);
+                res.status(409).json(res.locals.ret);
                 return;
             }
 

--- a/controllers/login.js
+++ b/controllers/login.js
@@ -54,7 +54,7 @@ const login = (async (req, res, next) =>
         if (query.length < 1)
         {
             ret.error = 'Username or password is incorrect.';
-            res.status(200).json(ret);
+            res.status(401).json(ret);
             return;
         }
         

--- a/controllers/login.js
+++ b/controllers/login.js
@@ -64,7 +64,7 @@ const login = (async (req, res, next) =>
             id: query[0]._id.toString(),
             login: body.Login
         }
-        ret.bearer = await generateJWT(tokenBody);
+        ret.bearer = 'Bearer ' + await generateJWT(tokenBody);
 
         // add user information
         ret.firstName = query[0].FirstName;

--- a/controllers/register.js
+++ b/controllers/register.js
@@ -40,7 +40,7 @@ const register = (async (req, res, next) =>
     if (_password !== _confirmPassword)
     {
         ret.error = "Passwords do not match.";
-        res.status(200).json(ret);
+        res.status(400).json(ret);
         return;
     }
     

--- a/controllers/register.js
+++ b/controllers/register.js
@@ -74,7 +74,7 @@ const register = (async (req, res, next) =>
                 id: newUser._id.toString(),
                 login: newUser.Login
             }
-            ret.bearer = await generateJWT(tokenBody);
+            ret.bearer = 'Bearer ' + await generateJWT(tokenBody);
         }
         
         // return success

--- a/controllers/register.js
+++ b/controllers/register.js
@@ -65,6 +65,8 @@ const register = (async (req, res, next) =>
         if (duplicate.length > 0)
         {
             ret.error = "Username is already taken.";
+            res.status(409).json(ret);
+            return;
         }
         else 
         {

--- a/controllers/removeFriend.js
+++ b/controllers/removeFriend.js
@@ -32,7 +32,7 @@ const removeFriend = (async (req, res, next) =>
         if (users.length < 1)
         {
             res.locals.ret.error = _friend + ' is not a user.';
-            res.status(200).json(res.locals.ret);
+            res.status(409).json(res.locals.ret);
             return;
         }
 
@@ -57,7 +57,7 @@ const removeFriend = (async (req, res, next) =>
         if (relationships.length < 1)
         {
             res.locals.ret.error = _friend + ' is not a friend.';
-            res.status(200).json(res.locals.ret);
+            res.status(409).json(res.locals.ret);
             return;
         }
         else


### PR DESCRIPTION
## Overview
Change the response status codes of some endpoints to better describe the received outputs. Also adds the `Bearer ` prefix to the bearer tokens in `/user/login` and `/user/register`.

#### Affected endpoints
-  `/friends/addFriend`
- `/friends/removeFriend`
- `/user/login`
- `/user/register`