### PR TITLE
Check upserted count

### DIFF
--- a/controllers/updateAssessments.js
+++ b/controllers/updateAssessments.js
@@ -65,7 +65,7 @@ const updateAssessment = (async (req, res, next) =>
             { upsert: true }
         );
 
-        if (update.modifiedCount < 1)
+        if (update.modifiedCount < 1 && update.upsertedCount < 1)
         {
             res.locals.ret.error = 'Responses already up-to-date.';
             res.status(409).json(res.locals.ret);


### PR DESCRIPTION
## Overview
Previously, we would check `modifiedCount` to see if a record was updated. However, this would miss if a record was upserted, and would respond that the record was up-to-date when, in fact, it was just created. This checks both `modifiedCount` and `upsertedCount` before responding that a record is up-to-date. 